### PR TITLE
Image downloading for Products and Skus

### DIFF
--- a/LocalFile.js
+++ b/LocalFile.js
@@ -1,0 +1,53 @@
+"use strict";
+
+const {
+  createRemoteFileNode
+} = require('gatsby-source-filesystem');
+
+class LocalFile {
+  constructor(createRemoteArgs) {
+    this.createRemoteArgs = createRemoteArgs;
+    this.fileFields = {
+      product: ["images"],
+      sku: ["image", "product.images"]
+    };
+  }
+
+  download(payload, type) {
+    const fields = this.fileFields[type.toLowerCase()];
+    fields.forEach(field => {
+      const splitPath = field.split(".");
+      let urls = this.getNestedObject(payload, splitPath);
+      if (!urls || !urls.length) return;
+      if (!Array.isArray(urls)) urls = [urls];
+      const sourceObject = splitPath.length >= 1 ? this.getNestedObject(payload, splitPath.slice(0, -1)) : payload;
+      sourceObject.localFiles___NODE = [];
+      urls.forEach(async url => {
+        let fileNode;
+
+        try {
+          fileNode = await createRemoteFileNode({
+            url,
+            ...this.createRemoteArgs
+          });
+        } catch (e) {
+          // Ignore
+          console.error(new Error(e));
+        }
+
+        if (fileNode) {
+          sourceObject.localFiles___NODE.push(fileNode.id);
+        }
+      });
+    });
+    return payload;
+  } // Access nested objects with path given as array.
+
+
+  getNestedObject(object, path) {
+    return path.reduce((obj, key) => obj[key], object);
+  }
+
+}
+
+module.exports = LocalFile;

--- a/LocalFile.js
+++ b/LocalFile.js
@@ -14,7 +14,7 @@ class LocalFile {
     };
   }
 
-  download(payload, type) {
+  downloadImages(payload, type) {
     const fields = this.fileFields[type.toLowerCase()];
     fields.forEach(field => {
       const splitPath = field.split(".");
@@ -43,7 +43,7 @@ class LocalFile {
     return payload;
   }
 
-  async downloadFile(payload) {
+  async downloadFiles(payload) {
     const updatedData = payload.data.map(async file => {
       let fileNode;
 

--- a/LocalFile.js
+++ b/LocalFile.js
@@ -9,7 +9,8 @@ class LocalFile {
     this.createRemoteArgs = createRemoteArgs;
     this.fileFields = {
       product: ["images"],
-      sku: ["image", "product.images"]
+      sku: ["image", "product.images"],
+      file: ["url"]
     };
   }
 
@@ -31,8 +32,7 @@ class LocalFile {
             ...this.createRemoteArgs
           });
         } catch (e) {
-          // Ignore
-          console.error(new Error(e));
+          console.log(e);
         }
 
         if (fileNode) {
@@ -40,6 +40,30 @@ class LocalFile {
         }
       });
     });
+    return payload;
+  }
+
+  async downloadFile(payload) {
+    const updatedData = payload.data.map(async file => {
+      let fileNode;
+
+      try {
+        fileNode = await createRemoteFileNode({
+          url: file.url,
+          ext: `.${file.type}`,
+          ...this.createRemoteArgs
+        });
+      } catch (e) {
+        console.log(e);
+      }
+
+      if (fileNode) {
+        file.localFiles___NODE = [fileNode.id];
+      }
+
+      return file;
+    });
+    payload.data = await Promise.all(updatedData);
     return payload;
   } // Access nested objects with path given as array.
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ In the plugin options objects' array, specify the object types you would like to
 
 Additionally, please only include your Stripe secret key via a [.env](https://www.npmjs.com/package/dotenv) file. We don't want your key ending up in your version-controlled source code!
 
+Enable [downloading images](#downloading-files) associated with your Stripe data by setting `downloadFiles` to true.
+
 Example below.
 
 ```javascript
@@ -38,7 +40,8 @@ plugins: [
     resolve: `gatsby-source-stripe`,
     options: {
       objects: ['Balance', 'BalanceTransaction', 'Product', 'ApplicationFee', 'Sku', 'Subscription'],
-      secretKey: 'stripe_secret_key_here'
+      secretKey: 'stripe_secret_key_here',
+      downloadFiles: true
     }
   }
 ]
@@ -96,19 +99,25 @@ Expanding all Stripe objects is tricky, as some objects have a lot of nested sub
 
 All list responses are fully paginated.
 
+## Downloading Files
+
+Setting `downloadFiles: true` in the plugin configuration enables downloading of images associated with Sku and Product objects. The images' [File nodes](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem#how-to-query) are placed on the `localFiles` field of the Sku and Product nodes.
+
+You can give these File nodes to plugins like [gatsby-image](https://using-gatsby-image.gatsbyjs.org/) to create responsive images and/or [gatsby-transformer-sharp](https://image-processing.gatsbyjs.org/) to process images at build.
+
 ## How to query
 
 You can query all of the different Stripe object data like the following:
 
 ```graphql
 {
-  allStripeCustomer {
+  allStripeSku {
     edges {
       node {
         id,
         active,
-        attributes,
-        skus {
+        localFiles,
+        product {
           id
         }
       }
@@ -117,7 +126,7 @@ You can query all of the different Stripe object data like the following:
 }
 ```
 
-Just replace "Customer" with any of the types used in your objects config array.
+Just replace "Sku" with any of the types used in your objects config array.
 
 You can also query for a specific Stripe object like this:
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ In the plugin options objects' array, specify the object types you would like to
 
 Additionally, please only include your Stripe secret key via a [.env](https://www.npmjs.com/package/dotenv) file. We don't want your key ending up in your version-controlled source code!
 
-Enable [downloading images](#downloading-files) associated with your Stripe data by setting `downloadFiles` to true.
+Enable [downloading files](#downloading-files) associated with your Stripe data by setting `downloadFiles` to true.
 
 Example below.
 
@@ -101,7 +101,7 @@ All list responses are fully paginated.
 
 ## Downloading Files
 
-Setting `downloadFiles: true` in the plugin configuration enables downloading of images associated with Sku and Product objects. The images' [File nodes](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem#how-to-query) are placed on the `localFiles` field of the Sku and Product nodes.
+Setting `downloadFiles: true` in the plugin configuration enables downloading of files associated with File objects, and images on Sku and Product objects. A Gatsby [File node](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem#how-to-query) is created for each downloaded file, and references are placed on the `localFiles` field of their Stripe nodes.
 
 You can give these File nodes to plugins like [gatsby-image](https://using-gatsby-image.gatsbyjs.org/) to create responsive images and/or [gatsby-transformer-sharp](https://image-processing.gatsbyjs.org/) to process images at build.
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -37,7 +37,12 @@ exports.sourceNodes = async ({
     store,
     cache,
     createNode,
-    createNodeId
+    createNodeId,
+    // Currently createRemoteFileNode discards auth headers with empty passwords
+    auth: {
+      htaccess_user: secretKey,
+      htaccess_pass: ""
+    }
   });
   const stripe = stripeClient(secretKey);
   stripe.setAppInfo({
@@ -66,7 +71,12 @@ exports.sourceNodes = async ({
      */
 
     if (!stripeObj.canIterate) {
-      const payload = await path[stripeObj.methodName](stripeObj.methodArgs);
+      let payload = await path[stripeObj.methodName](stripeObj.methodArgs);
+
+      if (downloadFiles) {
+        payload = await localFile.downloadFile(payload);
+      }
+
       const node = stripeObj.node(createContentDigest, payload);
       createNode(node);
       continue;

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -108,24 +108,21 @@ exports.sourceNodes = async ({
         *
         * Adds the localFiles field, which is an array of
         * references to the created File nodes.
+        *
+        * Currently only supports Product and Sku images.
         */
         const type = stripeObj.type.toLowerCase();
         const fileFields = {
           product: ["images"],
-          sku: ["image", "product.images"],
-          file: ["url"]
+          sku: ["image", "product.images"]
         };
 
         if (downloadFiles && fileFields[type]) {
           fileFields[type].forEach(field => {
             const splitPath = field.split(".");
-            const urls = Array.from(getNestedObject(payload, splitPath) || []);
-
-            if (!urls.length) {
-              // console.table({ type, splitPath });
-              return;
-            }
-
+            let urls = getNestedObject(payload, splitPath);
+            if (!urls || !urls.length) return;
+            if (!Array.isArray(urls)) urls = [urls];
             const sourceObject = splitPath.length >= 1 ? getNestedObject(payload, splitPath.slice(0, -1)) : payload;
             sourceObject.localFiles___NODE = [];
             urls.forEach(async url => {
@@ -141,7 +138,7 @@ exports.sourceNodes = async ({
                 });
               } catch (e) {
                 // Ignore
-                console.log(e, url);
+                console.log('\n', e);
               }
 
               if (fileNode) {
@@ -171,7 +168,7 @@ exports.sourceNodes = async ({
   }
 
   return;
-}; // Access nested objects, given as path array.
+}; // Access nested objects with path given as array.
 
 
 const getNestedObject = (object, path) => path.reduce((obj, key) => obj[key], object);

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -6,10 +6,18 @@ const stripeClient = require('stripe');
 
 const StripeObject = require('./StripeObject');
 
+const {
+  createRemoteFileNode
+} = require('gatsby-source-filesystem');
+
 exports.sourceNodes = async ({
   actions,
-  createContentDigest
+  cache,
+  createNodeId,
+  createContentDigest,
+  store
 }, {
+  downloadFiles = false,
   objects = [],
   secretKey = ""
 }) => {
@@ -93,6 +101,51 @@ exports.sourceNodes = async ({
           console.log(payload.data.object.attributes);
         }
         */
+
+        /*
+        * Download and create File nodes for object images, only if
+        * downloadFiles is configured.
+        *
+        * Adds the localFiles field, which is an array of
+        * references to the created File nodes.
+        *
+        * Currently only supports grabbing images from Product and Sku objects.
+        */
+        const fields = [];
+
+        if (downloadFiles) {
+          let fileNode;
+          if (payload.image) fields.push({
+            urls: [payload.image]
+          });
+          if (payload.images) fields.push({
+            urls: payload.images
+          });
+          if (payload.product && payload.product.images) fields.push({
+            urls: payload.product.images,
+            object: 'product'
+          });
+          fields.forEach(field => {
+            field.object ? payload[field.object].localFiles___NODE = [] : payload.localFiles___NODE = [];
+            field.urls.forEach(async url => {
+              fileNode = await createRemoteFileNode({
+                url,
+                store,
+                cache,
+                createNode,
+                createNodeId
+              });
+              if (!fileNode) return;
+
+              if (field.object) {
+                payload[field.object].localFiles___NODE.push(fileNode.id);
+              } else {
+                payload.localFiles___NODE.push(fileNode.id);
+              }
+            });
+          });
+        }
+
         const node = stripeObj.node(createContentDigest, payload);
         createNode(node);
       }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -74,7 +74,7 @@ exports.sourceNodes = async ({
       let payload = await path[stripeObj.methodName](stripeObj.methodArgs);
 
       if (downloadFiles) {
-        payload = await localFile.downloadFile(payload);
+        payload = await localFile.downloadFiles(payload);
       }
 
       const node = stripeObj.node(createContentDigest, payload);
@@ -126,7 +126,7 @@ exports.sourceNodes = async ({
         * Currently only supports Product and Sku images.
         */
         if (downloadFiles) {
-          payload = localFile.download(payload, stripeObj.type);
+          payload = localFile.downloadImages(payload, stripeObj.type);
         }
 
         const node = stripeObj.node(createContentDigest, payload);

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -41,7 +41,7 @@ exports.sourceNodes = async ({
     // Currently createRemoteFileNode discards auth headers with empty passwords
     auth: {
       htaccess_user: secretKey,
-      htaccess_pass: ""
+      htaccess_pass: "null"
     }
   });
   const stripe = stripeClient(secretKey);

--- a/localFile.js
+++ b/localFile.js
@@ -1,0 +1,49 @@
+"use strict";
+
+const {
+  createRemoteFileNode
+} = require('gatsby-source-filesystem');
+
+class LocalFile {
+  constructor(crfnArgs) {
+    this.crfnArgs = crfnArgs;
+    this.fileFields = {
+      product: ["images"],
+      sku: ["image", "product.images"]
+    };
+  }
+
+  download(payload, type) {
+    this.fileFields[type.toLowerCase()].forEach(field => {
+      const splitPath = field.split(".");
+      let urls = this.getNestedObject(payload, splitPath);
+      if (!urls || !urls.length) return;
+      if (!Array.isArray(urls)) urls = [urls];
+      const sourceObject = splitPath.length >= 1 ? this.getNestedObject(payload, splitPath.slice(0, -1)) : payload;
+      sourceObject.localFiles___NODE = [];
+      urls.forEach(async url => {
+        let fileNode;
+
+        try {
+          fileNode = await createRemoteFileNode({
+            url,
+            ...this.crfnArgs
+          });
+        } catch (e) {// Ignore
+        }
+
+        if (fileNode) {
+          sourceObject.localFiles___NODE.push(fileNode.id);
+        }
+      });
+    });
+  } // Access nested objects with path given as array.
+
+
+  static getNestedObject(object, path) {
+    path.reduce((obj, key) => obj[key], object);
+  }
+
+}
+
+module.exports = LocalFile;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1926,8 +1926,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2292,8 +2291,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2341,7 +2339,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2380,13 +2377,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1245,6 +1245,21 @@
         }
       }
     },
+    "@babel/runtime": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.5.tgz",
+      "integrity": "sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==",
+      "requires": {
+        "regenerator-runtime": "^0.12.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+        }
+      }
+    },
     "@babel/template": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
@@ -1315,17 +1330,38 @@
         }
       }
     },
+    "anymatch": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "requires": {
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
+      }
+    },
+    "arr-diff": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "requires": {
+        "arr-flatten": "^1.0.1"
+      }
+    },
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-      "dev": true
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
     },
     "arr-union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
+    },
+    "array-unique": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -1336,9 +1372,7 @@
     "async-each": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
-      "dev": true,
-      "optional": true
+      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
     },
     "atob": {
       "version": "2.1.2",
@@ -1349,8 +1383,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -1419,21 +1452,48 @@
         }
       }
     },
+    "better-queue": {
+      "version": "3.8.10",
+      "resolved": "https://registry.npmjs.org/better-queue/-/better-queue-3.8.10.tgz",
+      "integrity": "sha512-e3gwNZgDCnNWl0An0Tz6sUjKDV9m6aB+K9Xg//vYeo8+KiH8pWhLFxkawcXhm6FpM//GfD9IQv/kmvWCAVVpKA==",
+      "requires": {
+        "better-queue-memory": "^1.0.1",
+        "node-eta": "^0.9.0",
+        "uuid": "^3.0.0"
+      }
+    },
+    "better-queue-memory": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/better-queue-memory/-/better-queue-memory-1.0.3.tgz",
+      "integrity": "sha512-QLFkfV+k/7e4L4FR7kqkXKtRi22kl68c/3AaBs0ArDSz0iiuAl0DjVlb6gM220jW7izLE5TRy7oXOd4Cxa0wog=="
+    },
     "binary-extensions": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
-      "dev": true,
-      "optional": true
+      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+    },
+    "bluebird": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "requires": {
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "browserslist": {
@@ -1446,6 +1506,25 @@
         "electron-to-chromium": "^1.3.82",
         "node-releases": "^1.0.1"
       }
+    },
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "requires": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+    },
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -1483,6 +1562,22 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000907.tgz",
       "integrity": "sha512-No5sQ/OB2Nmka8MNOOM6nJx+Hxt6MQ6h7t7kgJFu9oTuwjykyKRSBP/+i/QAyFHxeHB+ddE0Da1CG5ihx9oehQ==",
       "dev": true
+    },
+    "chokidar": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+      "requires": {
+        "anymatch": "^1.3.0",
+        "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
+      }
     },
     "class-utils": {
       "version": "0.3.6",
@@ -1559,8 +1654,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "convert-source-map": {
       "version": "1.5.1",
@@ -1583,9 +1677,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true,
-      "optional": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "debug": {
       "version": "2.6.9",
@@ -1601,6 +1693,14 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
+    },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
     },
     "define-property": {
       "version": "2.0.2",
@@ -1655,6 +1755,11 @@
         }
       }
     },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+    },
     "electron-to-chromium": {
       "version": "1.3.84",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.84.tgz",
@@ -1672,6 +1777,22 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
+    },
+    "expand-brackets": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "requires": {
+        "is-posix-bracket": "^0.1.0"
+      }
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "requires": {
+        "fill-range": "^2.1.0"
+      }
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -1692,6 +1813,36 @@
             "is-plain-object": "^2.0.4"
           }
         }
+      }
+    },
+    "extglob": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "requires": {
+        "is-extglob": "^1.0.0"
+      }
+    },
+    "file-type": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.5.0.tgz",
+      "integrity": "sha512-zxVkZQY5rtw2H75SMPQUXJveD7uWGdaJJtsVBFfdW3m0W6UeBXzUwiIENFKQ2aRuPozTgBZYV6WhyeGOvs5YsA=="
+    },
+    "filename-regex": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+    },
+    "fill-range": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+      "requires": {
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^3.0.0",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "find-cache-dir": {
@@ -1717,8 +1868,15 @@
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "dev": true
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "requires": {
+        "for-in": "^1.0.1"
+      }
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -1727,6 +1885,16 @@
       "dev": true,
       "requires": {
         "map-cache": "^0.2.2"
+      }
+    },
+    "fs-extra": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs-readdir-recursive": {
@@ -1745,7 +1913,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
       "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
-      "dev": true,
       "optional": true,
       "requires": {
         "nan": "^2.9.2",
@@ -1755,24 +1922,21 @@
         "abbrev": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "delegates": "^1.0.0",
@@ -1782,13 +1946,11 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -1798,37 +1960,31 @@
         "chownr": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "ms": "2.0.0"
@@ -1837,25 +1993,21 @@
         "deep-extend": {
           "version": "0.5.1",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "minipass": "^2.2.1"
@@ -1864,13 +2016,11 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "aproba": "^1.0.3",
@@ -1886,7 +2036,6 @@
         "glob": {
           "version": "7.1.2",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -1900,13 +2049,11 @@
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "safer-buffer": "^2.1.0"
@@ -1915,7 +2062,6 @@
         "ignore-walk": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -1924,7 +2070,6 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "once": "^1.3.0",
@@ -1934,19 +2079,16 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -1955,13 +2097,11 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -1970,13 +2110,11 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
@@ -1986,7 +2124,6 @@
         "minizlib": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "minipass": "^2.2.1"
@@ -1995,7 +2132,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "minimist": "0.0.8"
@@ -2004,13 +2140,11 @@
         "ms": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "debug": "^2.1.2",
@@ -2021,7 +2155,6 @@
         "node-pre-gyp": {
           "version": "0.10.0",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
@@ -2039,7 +2172,6 @@
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "abbrev": "1",
@@ -2049,13 +2181,11 @@
         "npm-bundled": {
           "version": "1.0.3",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -2065,7 +2195,6 @@
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
@@ -2077,19 +2206,16 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "wrappy": "1"
@@ -2098,19 +2224,16 @@
         "os-homedir": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "os-homedir": "^1.0.0",
@@ -2120,19 +2243,16 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.7",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "deep-extend": "^0.5.1",
@@ -2144,7 +2264,6 @@
             "minimist": {
               "version": "1.2.0",
               "bundled": true,
-              "dev": true,
               "optional": true
             }
           }
@@ -2152,7 +2271,6 @@
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -2167,7 +2285,6 @@
         "rimraf": {
           "version": "2.6.2",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "glob": "^7.0.5"
@@ -2176,42 +2293,36 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -2222,7 +2333,6 @@
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -2231,7 +2341,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2239,13 +2349,11 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "chownr": "^1.0.1",
@@ -2260,13 +2368,11 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "string-width": "^1.0.2"
@@ -2275,14 +2381,40 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "optional": true
         }
       }
+    },
+    "gatsby-source-filesystem": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-2.0.9.tgz",
+      "integrity": "sha512-gvgGdpJVEhcWGIaNxBUH6HO09Y/l4GjgwK+4xvD6QltCgEgk/Y19iPHPAbhlxm40cmnjnntKap9JsgnsO0bc3w==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "better-queue": "^3.8.7",
+        "bluebird": "^3.5.0",
+        "chokidar": "^1.7.0",
+        "file-type": "^10.2.0",
+        "fs-extra": "^5.0.0",
+        "got": "^7.1.0",
+        "md5-file": "^3.1.1",
+        "mime": "^2.2.0",
+        "pretty-bytes": "^4.0.2",
+        "read-chunk": "^3.0.0",
+        "slash": "^1.0.0",
+        "valid-url": "^1.0.9",
+        "xstate": "^3.1.0"
+      }
+    },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-value": {
       "version": "2.0.6",
@@ -2304,17 +2436,67 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "requires": {
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "requires": {
+        "is-glob": "^2.0.0"
+      }
+    },
+    "got": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+      "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+      "requires": {
+        "decompress-response": "^3.2.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-plain-obj": "^1.1.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "isurl": "^1.0.0-alpha5",
+        "lowercase-keys": "^1.0.0",
+        "p-cancelable": "^0.3.0",
+        "p-timeout": "^1.1.1",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "url-parse-lax": "^1.0.0",
+        "url-to-options": "^1.0.1"
+      }
+    },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
+    },
+    "has-symbol-support-x": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+    },
+    "has-to-string-tag-x": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "requires": {
+        "has-symbol-support-x": "^1.4.1"
+      }
     },
     "has-value": {
       "version": "1.0.0",
@@ -2398,8 +2580,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "invariant": {
       "version": "2.2.4",
@@ -2423,8 +2604,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "dev": true,
-      "optional": true,
       "requires": {
         "binary-extensions": "^1.0.0"
       }
@@ -2432,8 +2611,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-data-descriptor": {
       "version": "0.1.4",
@@ -2463,17 +2641,54 @@
         }
       }
     },
+    "is-dotfile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "requires": {
+        "is-primitive": "^2.0.0"
+      }
+    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+    },
+    "is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+    },
+    "is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "requires": {
+        "is-extglob": "^1.0.0"
+      }
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "requires": {
+        "kind-of": "^3.0.2"
+      }
+    },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
     },
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "dev": true
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -2492,6 +2707,26 @@
         }
       }
     },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+    },
+    "is-retry-allowed": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -2502,8 +2737,24 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "requires": {
+        "isarray": "1.0.0"
+      }
+    },
+    "isurl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+      "requires": {
+        "has-to-string-tag-x": "^1.2.0",
+        "is-object": "^1.0.1"
+      }
     },
     "js-levenshtein": {
       "version": "1.1.4",
@@ -2517,11 +2768,18 @@
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -2563,6 +2821,11 @@
         "js-tokens": "^3.0.0"
       }
     },
+    "lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+    },
     "make-dir": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
@@ -2587,11 +2850,53 @@
         "object-visit": "^1.0.0"
       }
     },
+    "math-random": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
+    },
+    "md5-file": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-3.2.3.tgz",
+      "integrity": "sha512-3Tkp1piAHaworfcCgH0jKbTvj1jWWFgbvh2cXaNCgHwyTCBxxvD1Y04rmfpvdPm1P4oXMOpm6+2H7sr7v9v8Fw==",
+      "requires": {
+        "buffer-alloc": "^1.1.0"
+      }
+    },
+    "micromatch": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "requires": {
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
+      }
+    },
+    "mime": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
+      "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w=="
+    },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -2642,7 +2947,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
       "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-      "dev": true,
       "optional": true
     },
     "nanomatch": {
@@ -2688,6 +2992,11 @@
         }
       }
     },
+    "node-eta": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/node-eta/-/node-eta-0.9.0.tgz",
+      "integrity": "sha1-n7CwmbzSoCGUDmA8ZCVNwAPZp6g="
+    },
     "node-modules-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
@@ -2707,7 +3016,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
@@ -2751,6 +3059,15 @@
         }
       }
     },
+    "object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "requires": {
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
+      }
+    },
     "object.pick": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
@@ -2777,6 +3094,16 @@
         "wrappy": "1"
       }
     },
+    "p-cancelable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+      "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
     "p-limit": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
@@ -2795,11 +3122,30 @@
         "p-limit": "^1.1.0"
       }
     },
+    "p-timeout": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
+      "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
+    },
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
+    },
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "requires": {
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
+      }
     },
     "parse-passwd": {
       "version": "1.0.0",
@@ -2829,8 +3175,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-parse": {
       "version": "1.0.6",
@@ -2841,8 +3186,7 @@
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-      "dev": true
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
     "pirates": {
       "version": "4.0.0",
@@ -2869,6 +3213,21 @@
       "dev": true,
       "optional": true
     },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+    },
+    "preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+    },
+    "pretty-bytes": {
+      "version": "4.0.2",
+      "resolved": "http://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+      "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -2878,21 +3237,55 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
+    "randomatic": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+      "requires": {
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        }
+      }
+    },
+    "read-chunk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-3.0.0.tgz",
+      "integrity": "sha512-8lBUVPjj9TC5bKLBacB+rpexM03+LWiYbv6ma3BeWmUYXGxqA1WNNgIZHq/iIsCrbFMzPhFbkOqdsyOFRnuoXg==",
+      "requires": {
+        "pify": "^4.0.0",
+        "with-open-file": "^0.1.3"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+        }
+      }
+    },
     "readable-stream": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-      "dev": true,
-      "optional": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -2907,8 +3300,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-      "dev": true,
-      "optional": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "minimatch": "^3.0.2",
@@ -2944,6 +3335,14 @@
       "dev": true,
       "requires": {
         "private": "^0.1.6"
+      }
+    },
+    "regex-cache": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "requires": {
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "regex-not": {
@@ -2996,20 +3395,17 @@
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
     },
     "repeat-element": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-      "dev": true
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
     },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "resolve": {
       "version": "1.8.1",
@@ -3055,9 +3451,7 @@
     "set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-      "dev": true,
-      "optional": true
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
     },
     "set-value": {
       "version": "2.0.0",
@@ -3081,6 +3475,11 @@
           }
         }
       }
+    },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -3249,8 +3648,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "optional": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -3264,6 +3661,11 @@
         "qs": "~6.5.1",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -3376,6 +3778,11 @@
         }
       }
     },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    },
     "unset-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
@@ -3435,6 +3842,19 @@
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
+    "url-parse-lax": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "requires": {
+        "prepend-http": "^1.0.1"
+      }
+    },
+    "url-to-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
+    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -3444,15 +3864,45 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true,
-      "optional": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
+    },
+    "with-open-file": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/with-open-file/-/with-open-file-0.1.4.tgz",
+      "integrity": "sha512-BswUwq/x/BYtNFMr4Uw9V+P2uroc9/tcDpZ2RdDHehzwCKJFF1PSIjJmBNfpUE3UQyJmVINRLOW49WTXQMEnvg==",
+      "requires": {
+        "p-finally": "^1.0.0",
+        "p-try": "^2.0.0",
+        "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "p-try": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+        }
+      }
     },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "xstate": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-3.3.3.tgz",
+      "integrity": "sha512-p0ZYDPWxZZZRAJyD3jaGO9/MYioHuxZp6sjcLhPfBZHAprl4EDrZRGDqRVH9VvK8oa6Nrbpf+U5eNmn8KFwO3g=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1782,12 +1782,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1802,17 +1804,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1929,7 +1934,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1941,6 +1947,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1955,6 +1962,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1962,12 +1970,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1986,6 +1996,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2066,7 +2077,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2078,6 +2090,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2199,6 +2212,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   "bugs": "https://github.com/njosefbeck/gatsby-source-stripe/issues",
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": ">=1",
-    "gatsby-source-filesystem": "^2.0.4"
+    "gatsby": ">=1"
   },
   "devDependencies": {
     "@babel/cli": "7.1.5",
@@ -29,6 +28,7 @@
     "@babel/preset-env": "7.1.6"
   },
   "dependencies": {
+    "gatsby-source-filesystem": "^2.0.4",
     "stripe": "6.15.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "bugs": "https://github.com/njosefbeck/gatsby-source-stripe/issues",
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": ">=1"
+    "gatsby": ">=1",
+    "gatsby-source-filesystem": "^2.0.4"
   },
   "devDependencies": {
     "@babel/cli": "7.1.5",

--- a/src/LocalFile.js
+++ b/src/LocalFile.js
@@ -1,0 +1,52 @@
+const { createRemoteFileNode } = require('gatsby-source-filesystem');
+
+class LocalFile {
+  constructor(createRemoteArgs) {
+    this.createRemoteArgs = createRemoteArgs;
+    this.fileFields = {
+      product: ["images"],
+      sku: ["image", "product.images"]
+    };
+  }
+
+  download(payload, type) {
+    const fields = this.fileFields[type.toLowerCase()];
+
+    fields.forEach(field => {
+      const splitPath = field.split(".");
+      let urls = this.getNestedObject(payload, splitPath);
+      if (!urls || !urls.length) return;
+      if (!Array.isArray(urls)) urls = [urls];
+
+      const sourceObject = splitPath.length >= 1
+        ? this.getNestedObject(payload, splitPath.slice(0, -1))
+        : payload;
+      sourceObject.localFiles___NODE = [];
+
+      urls.forEach(async url => {
+        let fileNode;
+        try {
+          fileNode = await createRemoteFileNode({
+            url,
+            ...this.createRemoteArgs
+          });
+        } catch (e) {
+          // Ignore
+          console.error(new Error(e));
+        }
+
+        if (fileNode) {
+          sourceObject.localFiles___NODE.push(fileNode.id);
+        }
+      });
+    });
+    return payload;
+  }
+
+  // Access nested objects with path given as array.
+  getNestedObject (object, path) {
+    return path.reduce((obj, key) => (obj[key]), object);
+  }
+}
+
+module.exports = LocalFile;

--- a/src/LocalFile.js
+++ b/src/LocalFile.js
@@ -31,8 +31,7 @@ class LocalFile {
             ...this.createRemoteArgs
           });
         } catch (e) {
-          // Ignore
-          console.error(new Error(e));
+          console.log(e);
         }
 
         if (fileNode) {

--- a/src/LocalFile.js
+++ b/src/LocalFile.js
@@ -10,7 +10,7 @@ class LocalFile {
     };
   }
 
-  download(payload, type) {
+  downloadImages(payload, type) {
     const fields = this.fileFields[type.toLowerCase()];
 
     fields.forEach(field => {
@@ -43,7 +43,7 @@ class LocalFile {
     return payload;
   }
 
-  async downloadFile(payload) {
+  async downloadFiles(payload) {
     const updatedData = payload.data.map(async file => {
       let fileNode;
       try {

--- a/src/LocalFile.js
+++ b/src/LocalFile.js
@@ -5,7 +5,8 @@ class LocalFile {
     this.createRemoteArgs = createRemoteArgs;
     this.fileFields = {
       product: ["images"],
-      sku: ["image", "product.images"]
+      sku: ["image", "product.images"],
+      file: ["url"]
     };
   }
 
@@ -39,6 +40,28 @@ class LocalFile {
         }
       });
     });
+    return payload;
+  }
+
+  async downloadFile(payload) {
+    const updatedData = payload.data.map(async file => {
+      let fileNode;
+      try {
+        fileNode = await createRemoteFileNode({
+          url: file.url,
+          ext: `.${file.type}`,
+          ...this.createRemoteArgs
+        });
+      } catch (e) {
+        console.log(e);
+      }
+
+      if (fileNode) {
+        file.localFiles___NODE = [fileNode.id];
+      }
+      return file;
+    });
+    payload.data = await Promise.all(updatedData);
     return payload;
   }
 

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -97,8 +97,9 @@ exports.sourceNodes = async (
       if (downloadFiles && fileFields[type]) {
         fileFields[type].forEach(field => {
           const splitPath = field.split(".");
-          const urls = Array.from(getNestedObject(payload, splitPath) || []);
-          if (!urls.length) return;
+          let urls = getNestedObject(payload, splitPath);
+          if (!urls || !urls.length) return;
+          if (!Array.isArray(urls)) urls = [urls];
 
           const sourceObject = splitPath.length >= 1
             ? getNestedObject(payload, splitPath.slice(0, -1))
@@ -117,6 +118,7 @@ exports.sourceNodes = async (
               });
             } catch (e) {
               // Ignore
+              console.log('\n', e);
             }
 
             if (fileNode) {

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -59,7 +59,7 @@ exports.sourceNodes = async (
     if (!stripeObj.canIterate) {
       let payload = await path[stripeObj.methodName](stripeObj.methodArgs);
       if (downloadFiles) {
-        payload = await localFile.downloadFile(payload);
+        payload = await localFile.downloadFiles(payload);
       }
       const node = stripeObj.node(createContentDigest, payload);
       createNode(node);
@@ -101,7 +101,7 @@ exports.sourceNodes = async (
       * Currently only supports Product and Sku images.
       */
       if (downloadFiles) {
-        payload = localFile.download(payload, stripeObj.type);
+        payload = localFile.downloadImages(payload, stripeObj.type);
       }
 
       const node = stripeObj.node(createContentDigest, payload);

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -25,7 +25,7 @@ exports.sourceNodes = async (
     createNode,
     createNodeId,
     // Currently createRemoteFileNode discards auth headers with empty passwords
-    auth: { htaccess_user: secretKey, htaccess_pass: "" }
+    auth: { htaccess_user: secretKey, htaccess_pass: "null" }
   });
 
   const stripe = stripeClient(secretKey);

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -23,7 +23,9 @@ exports.sourceNodes = async (
     store,
     cache,
     createNode,
-    createNodeId
+    createNodeId,
+    // Currently createRemoteFileNode discards auth headers with empty passwords
+    auth: { htaccess_user: secretKey, htaccess_pass: "" }
   });
 
   const stripe = stripeClient(secretKey);
@@ -55,7 +57,10 @@ exports.sourceNodes = async (
      * based on testing the different object types.
      */
     if (!stripeObj.canIterate) {
-      const payload = await path[stripeObj.methodName](stripeObj.methodArgs);
+      let payload = await path[stripeObj.methodName](stripeObj.methodArgs);
+      if (downloadFiles) {
+        payload = await localFile.downloadFile(payload);
+      }
       const node = stripeObj.node(createContentDigest, payload);
       createNode(node);
       continue;
@@ -95,7 +100,6 @@ exports.sourceNodes = async (
       *
       * Currently only supports Product and Sku images.
       */
-
       if (downloadFiles) {
         payload = localFile.download(payload, stripeObj.type);
       }

--- a/stripeObject.js
+++ b/stripeObject.js
@@ -1,0 +1,47 @@
+"use strict";
+
+const stripeObjs = require('./stripeObjects.json');
+
+class StripeObject {
+  constructor(type) {
+    const obj = stripeObjs.objects.find(o => o.type === type);
+    this.id = obj.id;
+    this.product = obj.product;
+    this.name = obj.name;
+    this.type = obj.type;
+    this.description = obj.description;
+    this.canIterate = obj.canIterate;
+    this.methodName = obj.methodName;
+    this.methodArgs = obj.methodArgs;
+  }
+
+  objectPath(stripe) {
+    let path = null;
+
+    if (this.product) {
+      path = stripe[this.product][this.name];
+    } else {
+      path = stripe[this.name];
+    }
+
+    return path;
+  }
+
+  node(createContentDigest, payload) {
+    return Object.assign({}, payload, {
+      id: payload.id ? payload.id : `Stripe${this.type}${this.id}`,
+      parent: null,
+      children: [],
+      internal: {
+        mediaType: 'application/json',
+        type: `Stripe${this.type}`,
+        content: JSON.stringify(payload),
+        contentDigest: createContentDigest(payload),
+        description: this.description
+      }
+    });
+  }
+
+}
+
+module.exports = StripeObject;


### PR DESCRIPTION
As discussed in #8, this implements image downloading for Products, Skus, and the expanded product objects on Skus.

Downloading needs to be enabled with `downloadFiles: true` in the options object.

The Gatsby File nodes are referenced in the `localFiles` field.

```
{
  allStripeSku {
    edges {
      node {
        localFiles {
          id
        }
        product {
          localFiles {
            id
          }
        }
      }
    }
  }
}
```

I also want to implement this for Files, which shouldn't take much, but I wanted to see what you think of this implementation first, @njosefbeck! Any feedback is appreciated :+1: 