### PR TITLE
Improve file downloading #20

### DIFF
--- a/src/LocalFile.js
+++ b/src/LocalFile.js
@@ -10,13 +10,13 @@ class LocalFile {
     };
   }
 
-  downloadFiles(payload, type) {
+  async downloadFiles(payload, type) {
     if (type === "File") return this.downloadFileNode(payload);
     
     const fields = this.fileFields[type.toLowerCase()];
     if (!fields) return payload;
 
-    fields.forEach(field => {
+    for (let field of fields) {
       const splitPath = field.split(".");
       let urls = this.getNestedObject(payload, splitPath);
       if (!urls || !urls.length) return;
@@ -25,9 +25,10 @@ class LocalFile {
       const sourceObject = splitPath.length >= 1
         ? this.getNestedObject(payload, splitPath.slice(0, -1))
         : payload;
+      
       sourceObject.localFiles___NODE = [];
 
-      urls.forEach(async url => {
+      for (const url of urls) {
         let fileNode;
         try {
           fileNode = await createRemoteFileNode({
@@ -42,8 +43,8 @@ class LocalFile {
         if (fileNode) {
           sourceObject.localFiles___NODE.push(fileNode.id);
         }
-      });
-    });
+      }
+    }
     return payload;
   }
 

--- a/src/LocalFile.js
+++ b/src/LocalFile.js
@@ -32,6 +32,7 @@ class LocalFile {
         try {
           fileNode = await createRemoteFileNode({
             url,
+            parentNodeId: sourceObject.id,
             ...this.createRemoteArgs
           });
         } catch (e) {
@@ -52,6 +53,7 @@ class LocalFile {
       try {
         fileNode = await createRemoteFileNode({
           url: file.url,
+          parentNodeId: file.id,
           ext: `.${file.type}`,
           ...this.createRemoteArgs
         });

--- a/src/LocalFile.js
+++ b/src/LocalFile.js
@@ -1,80 +1,85 @@
-const { createRemoteFileNode } = require('gatsby-source-filesystem');
+const { createRemoteFileNode } = require('gatsby-source-filesystem')
 
 class LocalFile {
   constructor(createRemoteArgs) {
-    this.createRemoteArgs = createRemoteArgs;
+    this.createRemoteArgs = createRemoteArgs
     this.fileFields = {
-      product: ["images"],
-      sku: ["image", "product.images"],
-      file: ["url"]
-    };
+      product: ['images'],
+      sku: ['image', 'product.images'],
+      file: ['url'],
+    }
   }
 
   async downloadFiles(payload, type) {
-    if (type === "File") return this.downloadFileNode(payload);
-    
-    const fields = this.fileFields[type.toLowerCase()];
-    if (!fields) return payload;
+    if (type === 'File') return this.downloadFileNode(payload)
 
-    for (let field of fields) {
-      const splitPath = field.split(".");
-      let urls = this.getNestedObject(payload, splitPath);
-      if (!urls || !urls.length) return;
-      if (!Array.isArray(urls)) urls = [urls];
+    const fields = this.fileFields[type.toLowerCase()]
+    if (!fields) return payload
 
-      const sourceObject = splitPath.length >= 1
-        ? this.getNestedObject(payload, splitPath.slice(0, -1))
-        : payload;
-      
-      sourceObject.localFiles___NODE = [];
+    await Promise.all(
+      fields.map(async field => {
+        const splitPath = field.split('.')
+        let urls = this.getNestedObject(payload, splitPath)
+        if (!urls || !urls.length) return
+        if (!Array.isArray(urls)) urls = [urls]
 
-      for (const url of urls) {
-        let fileNode;
-        try {
-          fileNode = await createRemoteFileNode({
-            url,
-            parentNodeId: sourceObject.id,
-            ...this.createRemoteArgs
-          });
-        } catch (e) {
-          console.log(e);
-        }
+        const sourceObject =
+          splitPath.length >= 1
+            ? this.getNestedObject(payload, splitPath.slice(0, -1))
+            : payload
 
-        if (fileNode) {
-          sourceObject.localFiles___NODE.push(fileNode.id);
-        }
-      }
-    }
-    return payload;
+        sourceObject.localFiles___NODE = []
+
+        await Promise.all(
+          urls.map(async url => {
+            let fileNode
+            try {
+              fileNode = await createRemoteFileNode({
+                url,
+                parentNodeId: sourceObject.id,
+                ...this.createRemoteArgs,
+              })
+            } catch (e) {
+              console.log(e)
+            }
+
+            if (fileNode) {
+              sourceObject.localFiles___NODE.push(fileNode.id)
+            }
+          })
+        )
+      })
+    )
+    return payload
   }
 
   async downloadFileNode(payload) {
     const updatedData = payload.data.map(async file => {
-      let fileNode;
+      let fileNode
       try {
         fileNode = await createRemoteFileNode({
           url: file.url,
           parentNodeId: file.id,
           ext: `.${file.type}`,
-          ...this.createRemoteArgs
-        });
+          ...this.createRemoteArgs,
+        })
       } catch (e) {
-        console.log(e);
+        console.log(e)
       }
 
       if (fileNode) {
-        file.localFiles___NODE = [fileNode.id];
+        file.localFiles___NODE = [fileNode.id]
       }
-      return file;
-    });
-    payload.data = await Promise.all(updatedData);
-    return payload;
+      return file
+    })
+    payload.data = await Promise.all(updatedData)
+    return payload
   }
 
   // Access nested objects with path given as array.
-  getNestedObject (object, path) {
-    return path.reduce((obj, key) => (obj[key]), object);
+  getNestedObject(object, path) {
+    return path.reduce((obj, key) => obj[key], object)
   }
 }
 
-module.exports = LocalFile;
+module.exports = LocalFile

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -96,7 +96,7 @@ exports.sourceNodes = async (
       * Currently supports File, Product and Sku images.
       */
       if (downloadFiles) {
-        payload = localFile.downloadFiles(payload, stripeObj.type);
+        payload = await localFile.downloadFiles(payload, stripeObj.type);
       }
 
       const node = stripeObj.node(createContentDigest, payload);


### PR DESCRIPTION
This should fix #20, so that all files should be finished downloading by the time sourceNodes() returns. Also createFileNode is now given the parent node id, in accordance with the changes to its API. In my brief testing this fixed some issues with cached nodes and the development server, as was suggested. Thanks @KyleAMathews for helping improve this!