### PR TITLE
Remove auth option, fixed file download, and refactored LocalFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add .eslintignore to ignore tests dir when running eslint.
 - Add prebuild npm script to handle deleting old JavaScript files on build.
 - Fix capitalization issue: stripeObject.js --> StripeObject.js
+- Removed auth option as without the ability to give custom auth credentials its redundant.
+- Refactored LocalFile.js to no longer differentiate between Stripe and non-Stripe hosted files.
+- Fixed issue with convertToArray method returning an empty array when provided with an object.
 
 ## [2.2.2](https://github.com/njosefbeck/gatsby-source-stripe/compare/v2.2.1...v2.2.2) - 2019-04-13
 - Fix file capitalization issue.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ In the plugin options objects' array, specify the object types you would like to
 
 Additionally, please only include your Stripe secret key via a [.env](https://www.npmjs.com/package/dotenv) file that is not version-controlled. We don't want your key ending up in your version-controlled source code! For enhanced security, you can also create a [restricted API key](https://stripe.com/docs/keys#limiting-access-with-restricted-api-keys) in your Stripe Developer Dashboard. Since this plugin only ever sources data, you can restrict `All core resources` to `Read only`, and even turn off access to certain resources that you know you don't use.
 
-Enable [downloading files](#downloading-files) associated with your Stripe data by setting `downloadFiles` to true. You can also set `auth` to false as shown below to remove any Authorization header from HTTP requests made when [downloading files](#downloading-files) not hosted on Stripe.
+Enable [downloading files](#downloading-files) associated with your Stripe data by setting `downloadFiles` to true.
 
 Example below.
 
@@ -42,7 +42,6 @@ plugins: [
       objects: ['Balance', 'BalanceTransaction', 'Product', 'ApplicationFee', 'Sku', 'Subscription'],
       secretKey: 'stripe_secret_key_here',
       downloadFiles: true,
-      auth: false,
     }
   }
 ]
@@ -104,7 +103,7 @@ All list responses are fully paginated.
 
 Setting `downloadFiles: true` in the plugin configuration enables downloading of files associated with File objects, and images on Sku and Product objects. A Gatsby [File node](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem#how-to-query) is created for each downloaded file, and references are placed on the `localFiles` field of their Stripe nodes.
 
-When downloading these files this plugin will by default use the same authorization header used in the HTTP request for fetching your Stripe details. This can cause some issues with platforms used to host public files (e.g. Google Cloud Platform Storage Buckets) where you will receive a 401 Unauthorized since this header won't match anything the platform knows about. As such you can choose to remove the auth header using the setting `auth: false`. Currently you can not set custom auth headers due to limitations in [gatsby-source-filesystem](https://www.gatsbyjs.org/packages/gatsby-source-filesystem/), however this limitation may be removed in the future.
+This plugin will automatically use your Stripe secret key for authentication when fetching files hosted by Stripe that aren't public (don't have an associated File Link). Any images that you are hosting yourself need to be public. Currently you can not set custom auth headers due to limitations in [gatsby-source-filesystem](https://www.gatsbyjs.org/packages/gatsby-source-filesystem/), however this limitation may be removed in the future.
 
 You can give these File nodes to plugins like [gatsby-image](https://using-gatsby-image.gatsbyjs.org/) to create responsive images and/or [gatsby-transformer-sharp](https://image-processing.gatsbyjs.org/) to process images at build.
 

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -6,7 +6,7 @@ const checkForStripeObjects = require("./checkForStripeObjects")
 
 exports.sourceNodes = async (
   { actions, cache, createNodeId, createContentDigest, store },
-  { downloadFiles = false, objects = [], secretKey = "", auth = true }
+  { downloadFiles = false, objects = [], secretKey = "" }
 ) => {
   const { createNode } = actions;
 
@@ -95,8 +95,7 @@ exports.sourceNodes = async (
       if (downloadFiles) {
         fileNodesMap = await localFile.downloadFiles(
           payload,
-          stripeObj.type,
-          auth
+          stripeObj.type
         );
       }
 


### PR DESCRIPTION
We had previously made the distinction between files hosted on Stripe and those that weren't because we assumed that all files hosted on Stripe needed authentication. We now know that some Files hosted on Stripe are public while others are private, which makes this distinction unnecessary. Now we have a single method that allows you to specify whether you would like to authenticate or not. 

Also fixed an issue with the convertToArray method where it incorrectly converted an object to an empty array.

Finally removed the auth option because it is currently redundant (we know which files do and don't need authentication thanks to Stripes docs).