### PR TITLE
Remove node.internal.mediaType from StripeObject

### DIFF
--- a/src/StripeObject.js
+++ b/src/StripeObject.js
@@ -36,7 +36,6 @@ class StripeObject {
       parent: null,
       children: [],
       internal: {
-        mediaType: "application/json",
         type: `Stripe${this.type}`,
         content: JSON.stringify(payload),
         contentDigest: createContentDigest(payload),


### PR DESCRIPTION
Removing the `mediaType` stops collisions with `gatsby-transformer-json` from happening