### PR TITLE
Don't skip sku.product.localFiles when sku.image is not present #42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-- None
+- Fix an issue where the images of a `Sku`'s expanded product field are not downloaded if the `Sku` has no image itself.
 
 ## [3.0.2](https://github.com/njosefbeck/gatsby-source-stripe/compare/v3.0.1...v3.0.2) - 2019-07-26
 - Remove `mediaType` from StripeObject Gatsby node, to solve bug related to using this plugin in the same project as `gatsby-tranformer-json`. Update relevant test.

--- a/src/__tests__/hasFilesToDownload.test.js
+++ b/src/__tests__/hasFilesToDownload.test.js
@@ -66,4 +66,33 @@ describe("hasFilesToDownload()", () => {
 
     expect(hasFilesToDownload(node)).toBe(expected);
   });
+
+  test("returns true when only subnode has image", () => {
+    const productNode = {
+      id: "prod_EyUMnCrvQMhw3b",
+      object: "product",
+      images: [
+        "https://images.ctfassets.net/wubeq4r3otg9/4z8w2ARN4Qk2qUKeWIaMa6/d75a0e74446c6e1df1155b754b92372d/black.png",
+        "https://images.ctfassets.net/wubeq4r3otg9/3q7n4GuUhWaQY82Iw64KEq/9dffaeb403227171594c2dda9a5df333/rainbow.png",
+        "https://njosefbeck.github.io/lets-watch-sailormoon/static/media/sailor_moon_logo.1630c2ed.png"
+      ],
+      type: "good",
+      updated: 1556536238
+    };
+
+    const node = {
+      id: "sku_Ew1GWVDLcI23bd",
+      object: "sku",
+      image: null,
+      product: productNode,
+      updated: 1555966756,
+      parent: null,
+      children: [],
+      internal: {}
+    };
+
+    const expected = true;
+
+    expect(hasFilesToDownload(node)).toBe(expected);
+  });
 });

--- a/src/helpers/hasFilesToDownload.js
+++ b/src/helpers/hasFilesToDownload.js
@@ -1,7 +1,8 @@
 function hasFilesToDownload(node) {
   const hasImages = node.images && node.images.length;
   const hasImage = node.image && node.image.length;
-  return hasImages || hasImage ? true : false;
+  const hasProductImages = node.product && hasFilesToDownload(node.product);
+  return hasImages || hasImage || hasProductImages ? true : false;
 }
 
 module.exports = hasFilesToDownload;


### PR DESCRIPTION
Fixes #42 

> hasFilesToDownload will return false if a sku doesn't have an image, regardless of it's product.images field.

@njosefbeck hopefully you think this is a good way to solve it!