### PR TITLE
Fix parameter of touchNode as API changed

### DIFF
--- a/src/helpers/checkCache.js
+++ b/src/helpers/checkCache.js
@@ -9,7 +9,11 @@ async function checkCache({ cache, getNode, touchNode, url, node }) {
     const fileNode = getNode(cachedFileData.fileNodeId);
 
     if (fileNode) {
-      saveNodeFromGarbageCollection(touchNode, cachedFileData.fileNodeId);
+      saveNodeFromGarbageCollection(
+        touchNode,
+        getNode,
+        cachedFileData.fileNodeId
+      );
       return cachedFileData.fileNodeId;
     }
   }

--- a/src/helpers/saveNodeFromGarbageCollection.js
+++ b/src/helpers/saveNodeFromGarbageCollection.js
@@ -1,5 +1,5 @@
-function saveNodeFromGarbageCollection(touchNode, nodeId) {
-  touchNode({ nodeId });
+function saveNodeFromGarbageCollection(touchNode, getNode, nodeId) {
+  touchNode(getNode(nodeId));
 }
 
 module.exports = saveNodeFromGarbageCollection;


### PR DESCRIPTION
Fixes the issue related to [this deprecation](https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v2-to-v3/#touchnode) in Gatsby v3.

```
Calling "touchNode" with an object containing the nodeId is deprecated.
Please pass the node directly to the function: touchNode(node)
```

Fixes https://github.com/njosefbeck/gatsby-source-stripe/issues/69
