### PR TITLE
Expand 'currency_options' field on Price

### DIFF
--- a/src/stripeObjects.json
+++ b/src/stripeObjects.json
@@ -423,7 +423,7 @@
       "canIterate": true,
       "methodName": "list",
       "methodArgs": {
-        "expand": ["data.product", "data.tiers"]
+        "expand": ["data.product", "data.tiers", "data.currency_options"]
       }
     },
     {


### PR DESCRIPTION
@njosefbeck 

Thank you so much for putting together this package!

I have an online shop where I'd like to use multi-currency prices.

So I need to expand the `currency_options` field on the `Price` object.

Here is a link to the documentation: https://docs.stripe.com/api/prices/object#price_object-currency_options

Following this [issue](https://github.com/njosefbeck/gatsby-source-stripe/issues/5#issue-381979816), I have opened this pull request.

Is this something you can test and release? 
